### PR TITLE
Fix to use the embedded cert

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,6 +29,8 @@ before_cache:
 matrix:
   exclude:
     - scala: 2.11.12
+      jdk: oraclejdk8
+    - scala: 2.11.12
       jdk: oraclejdk9
     - scala: 2.11.12
       jdk: oraclejdk10

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,8 @@ jdk:
 env:
   matrix:
     - SCRIPT=scripts/test-sbt
-    - SCRIPT=scripts/test-gradle
+    # https://github.com/akka/akka-grpc/issues/342
+    #- SCRIPT=scripts/test-gradle
 script:
 - $SCRIPT
 cache:
@@ -28,12 +29,16 @@ before_cache:
 # https://docs.travis-ci.com/user/customizing-the-build/#Build-Matrix
 matrix:
   exclude:
+    # https://github.com/akka/akka-grpc/issues/345
     - scala: 2.11.12
       jdk: oraclejdk8
+    # https://github.com/akka/akka-grpc/issues/345
     - scala: 2.11.12
       jdk: oraclejdk9
+    # https://github.com/akka/akka-grpc/issues/345
     - scala: 2.11.12
       jdk: oraclejdk10
+    # https://github.com/akka/akka-grpc/issues/345
     - scala: 2.11.12
       jdk: oraclejdk11
   allow_failures:

--- a/build.sbt
+++ b/build.sbt
@@ -24,6 +24,12 @@ crossScalaVersions := Seq("2.11.12", "2.12.6")
 
 libraryDependencies += guice
 
+// There is a bug in akka-http 10.1.4 that makes it not work with gRPC+Play,
+// so we need to downgrade to 10.1.3 (or move to 10.1.5 when that's out)
+// https://github.com/akka/akka-http/issues/2168
+dependencyOverrides += "com.typesafe.akka" %% "akka-http-core" % "10.1.3"
+dependencyOverrides += "com.typesafe.akka" %% "akka-http" % "10.1.3"
+
 // Test Database
 libraryDependencies += "com.h2database" % "h2" % "1.4.197"
 

--- a/build.sbt
+++ b/build.sbt
@@ -14,7 +14,7 @@ lazy val root = (project in file("."))
       PlayKeys.devSettings ++= Seq(
         "play.server.http.port" -> "disabled",
         "play.server.https.port" -> "9443",
-        "play.server.https.keyStore.path" -> "./generated.keystore",
+        "play.server.https.keyStore.path" -> "conf/selfsigned.keystore",
       )
     )
 


### PR DESCRIPTION
Project doesn't run currently in dev mode because the cert path is incorrect in one place.

Note: if you want to test this you'll need to downgrade akka-grpc to 0.2-RC1 because akka-grpc 0.2 is not compatible with Play.